### PR TITLE
Changing the Classes Per Week displayed by changing the daysOfWeek variable

### DIFF
--- a/public/default-amrta-cse-sem2.json
+++ b/public/default-amrta-cse-sem2.json
@@ -7,7 +7,8 @@
     "present": 29,
     "absent": 3,
     "percentage": 90.63,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 1
   },
   {
     "Sl_No": "2",
@@ -17,7 +18,8 @@
     "present": 14,
     "absent": 4,
     "percentage": 77.78,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 1
   },
   {
     "Sl_No": "3",
@@ -27,7 +29,8 @@
     "present": 62,
     "absent": 10,
     "percentage": 86.11,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 3
   },
   {
     "Sl_No": "4",
@@ -37,7 +40,8 @@
     "present": 47,
     "absent": 5,
     "percentage": 90.38,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 2
   },
   {
     "Sl_No": "5",
@@ -47,7 +51,8 @@
     "present": 54,
     "absent": 14,
     "percentage": 79.41,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 3
   },
   {
     "Sl_No": "6",
@@ -57,17 +62,19 @@
     "present": 51,
     "absent": 13,
     "percentage": 79.69,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 3
   },
   {
     "Sl_No": "7",
-    "Course": "Manufacturing Practice",
-    "CourseAbbreviation": "M.P",
+    "Course": "Technical Communication",
+    "CourseAbbreviation": "T.C",
     "total": 41,
     "present": 30,
     "absent": 11,
     "percentage": 73,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 2
   },
   {
     "Sl_No": "8",
@@ -77,6 +84,7 @@
     "present": 35,
     "absent": 8,
     "percentage": 81.4,
-    "MinAttendancePercentage": 75
+    "MinAttendancePercentage": 75,
+    "daysPerWeek": 2
   }
 ]

--- a/public/default-amrta-cse-sem2.json
+++ b/public/default-amrta-cse-sem2.json
@@ -8,18 +8,18 @@
     "absent": 3,
     "percentage": 90.63,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 2
+    "daysOfWeek": [1,5]
   },
   {
     "Sl_No": "2",
-    "Course": "Technical Communicatoin",
+    "Course": "Technical Communication",
     "CourseAbbreviation": "T.C",
     "total": 18,
     "present": 14,
     "absent": 4,
     "percentage": 77.78,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 3
+    "daysOfWeek": [3,4]
   },
   {
     "Sl_No": "3",
@@ -30,7 +30,7 @@
     "absent": 10,
     "percentage": 86.11,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 4
+    "daysOfWeek": [1,3,4,5]
   },
   {
     "Sl_No": "4",
@@ -41,7 +41,7 @@
     "absent": 5,
     "percentage": 90.38,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 3
+    "daysOfWeek": [1,2,5]
   },
   {
     "Sl_No": "5",
@@ -52,7 +52,7 @@
     "absent": 14,
     "percentage": 79.41,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 4
+    "daysOfWeek": [1,2,3,5]
   },
   {
     "Sl_No": "6",
@@ -63,7 +63,7 @@
     "absent": 13,
     "percentage": 79.69,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 4
+    "daysOfWeek": [1,2,3,4]
   },
   {
     "Sl_No": "8",
@@ -74,6 +74,6 @@
     "absent": 8,
     "percentage": 81.4,
     "MinAttendancePercentage": 75
-    "dayPerWeek": 3
+    "daysOfWeek": [1,2,4]
   }
 ]

--- a/public/default-amrta-cse-sem2.json
+++ b/public/default-amrta-cse-sem2.json
@@ -7,19 +7,19 @@
     "present": 29,
     "absent": 3,
     "percentage": 90.63,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 1
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 2
   },
   {
     "Sl_No": "2",
-    "Course": "Coding Classes",
-    "CourseAbbreviation": "C.C",
+    "Course": "Technical Communicatoin",
+    "CourseAbbreviation": "T.C",
     "total": 18,
     "present": 14,
     "absent": 4,
     "percentage": 77.78,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 1
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 3
   },
   {
     "Sl_No": "3",
@@ -29,8 +29,8 @@
     "present": 62,
     "absent": 10,
     "percentage": 86.11,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 3
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 4
   },
   {
     "Sl_No": "4",
@@ -40,8 +40,8 @@
     "present": 47,
     "absent": 5,
     "percentage": 90.38,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 2
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 3
   },
   {
     "Sl_No": "5",
@@ -51,8 +51,8 @@
     "present": 54,
     "absent": 14,
     "percentage": 79.41,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 3
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 4
   },
   {
     "Sl_No": "6",
@@ -62,19 +62,8 @@
     "present": 51,
     "absent": 13,
     "percentage": 79.69,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 3
-  },
-  {
-    "Sl_No": "7",
-    "Course": "Technical Communication",
-    "CourseAbbreviation": "T.C",
-    "total": 41,
-    "present": 30,
-    "absent": 11,
-    "percentage": 73,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 2
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 4
   },
   {
     "Sl_No": "8",
@@ -84,7 +73,7 @@
     "present": 35,
     "absent": 8,
     "percentage": 81.4,
-    "MinAttendancePercentage": 75,
-    "daysPerWeek": 2
+    "MinAttendancePercentage": 75
+    "dayPerWeek": 3
   }
 ]


### PR DESCRIPTION
Considering the review on the Chrome Web Store:
https://chromewebstore.google.com/reviews/2f4d99d4-4519-4e50-8e33-3f7f9214a0c7
Trying to add the daysOfWeek list for fixing the problem of showing `Classes per week:  0` on clicking the info button in the dashboard.